### PR TITLE
fix support for python3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,22 +4,20 @@ on: [ push ]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
+      - name: Install poetry
+        run: pipx install poetry
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
-          # cache: 'pipenv' # caching pipenv dependencies
-      - name: Install poetry and pipx
-        run: |
-          pip install poetry && pip install pipx
-
-      - name: Install global dependencies
-        run: |
-          pipx install isort && pipx install black && pipx install bandit && \
-          pipx install pylint && pipx install pre-commit && pipx install poetry
+          python-version: ${{ matrix.python }}
+          cache: poetry
 
       - name: Install Dependencies
         run: poetry install --with dev

--- a/terminaltables3/ascii_table.py
+++ b/terminaltables3/ascii_table.py
@@ -1,5 +1,7 @@
 """AsciiTable is the main table class. To be inherited by other tables. Define convenience methods here."""
 
+from typing import List
+
 from terminaltables3.base_table import BaseTable
 from terminaltables3.terminal_io import terminal_size
 from terminaltables3.width_and_alignment import (
@@ -41,7 +43,7 @@ class AsciiTable(BaseTable):
         )
 
     @property
-    def column_widths(self) -> list[int]:
+    def column_widths(self) -> List[int]:
         """Return a list of integers representing the widths of each table column without padding."""
         if not self.table_data:
             return []

--- a/terminaltables3/width_and_alignment.py
+++ b/terminaltables3/width_and_alignment.py
@@ -2,7 +2,7 @@
 
 import re
 import unicodedata
-from typing import Sequence, Tuple
+from typing import List, Sequence, Tuple
 
 from terminaltables3.terminal_io import terminal_size
 
@@ -46,7 +46,7 @@ def align_and_pad_cell(
     inner_dimensions: Tuple,
     padding: Sequence[int],
     space: str = " ",
-) -> list[str]:
+) -> List[str]:
     """Align a string horizontally and vertically. Also add additional padding in both dimensions.
 
     :param str string: Input string to operate on.
@@ -131,7 +131,7 @@ def max_dimensions(
             inner_heights[j] = max(inner_heights[j], cell.count("\n") + 1)
             inner_widths[i] = max(
                 inner_widths[i],
-                *[visible_width(the_line) for the_line in cell.splitlines()]
+                *[visible_width(the_line) for the_line in cell.splitlines()],
             )
 
     # Calculate with padding.


### PR DESCRIPTION
`list[int]` isn't a valid type annotation until python3.9, so this currently [fails](https://github.com/branchvincent/terminaltables3/actions/runs/10126810971/job/28003876705)
